### PR TITLE
Add OpennNI 2 driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,92 @@
-CXX = nvcc
-CC = nvcc
-CPPFLAGS=-I../include -I../include/libfreenect -I/usr/loca/cuda/include -I/opt/local/include -DLIBFREENECT_INTERFACE
-CXXFLAGS=-g -m64 -O3 -use_fast_math
-## -ptx -src-in-ptx
-LDFLAGS=-g -m64 -L../lib -lfreenect -Xlinker
+# When editing this Makefile, please make sure all variables apart from
+# the KF_* and ALL_* variables stay overridable from outside.
+# KF_* variables *may* be set from outside (like KF_DRIVER).
 
-OS := $(shell uname)
-ifeq ($(OS),Darwin)
-LDFLAGS+=-framework,OpenGL,-framework,GLUT
-else
-LDFLAGS+=-lGL -lglut
+CC ?= gcc
+CXX ?= g++
+NVCC ?= nvcc
+
+# Can be either 'libfreenect' or 'openni2'.
+# If not given, it's 'libfreenect' by default.
+KF_DRIVER ?= libfreenect
+
+# You can set the following path variables for this Makefile:
+#   CUDA_INCLUDE_PATH
+#   OPENNI2_INCLUDE_PATH
+#   LIBFREENECT_INCLUDE_PATH
+
+
+# Default flags
+KF_CPPFLAGS = -Ithirdparty
+KF_CXXFLAGS = -g -m64 -O3
+KF_NVCCFLAGS = -g -m64 -O3 -use_fast_math
+KF_LDFLAGS = -g -m64 -lpthread -Xlinker -lcudart
+
+ifdef CUDA_INCLUDE_PATH
+  KF_CPPFLAGS += -I$(CUDA_INCLUDE_PATH)
 endif
 
-%.o: %.cu
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $^
+# Driver dependent flags
 
+# For using libfreenect
+ifeq ($(KF_DRIVER),libfreenect)
+  KF_CPPFLAGS += -DLIBFREENECT_INTERFACE
+  ifdef LIBFREENECT_INCLUDE_PATH
+    KF_CPPFLAGS += -I$(LIBFREENECT_INCLUDE_PATH)
+  endif
+  KF_LDFLAGS += -lfreenect
+# For using OpenNI2
+else ifeq ($(KF_DRIVER),openni2)
+  KF_CPPFLAGS += -DOPENNI2_INTERFACE
+  ifdef OPENNI2_INCLUDE_PATH
+    KF_CPPFLAGS += -I$(OPENNI2_INCLUDE_PATH)
+  endif
+  KF_LDFLAGS += -lOpenNI2
+else
+  $(error KF_DRIVER is not set to a possible driver)
+endif
+
+# OS dependent flags
+
+KF_OS := $(shell uname)
+ifeq ($(KF_OS),Darwin)
+  KF_LDFLAGS += -framework,OpenGL,-framework,GLUT
+else
+  KF_LDFLAGS += -lGL -lglut
+endif
+
+
+# Concatenate our and user flags
+ALL_CPPFLAGS := $(KF_CPPFLAGS) $(CPPFLAGS)
+ALL_CXXFLAGS := $(KF_CXXFLAGS) $(CXXFLAGS)
+ALL_NVCCFLAGS := $(KF_NVCCFLAGS) $(NVCCFLAGS)
+ALL_LDFLAGS := $(KF_LDFLAGS) $(LDFLAGS)
+
+
+# Default target
+.PHONY: all
 all: kinect test
 
-test: kfusion.o helpers.o test.o
 
-kinect: kfusion.o helpers.o kinect.o interface.o
+# .cpp files
+%.o: %.cpp
+	$(CXX) $(ALL_CXXFLAGS) $(ALL_CPPFLAGS) -c -o $@ $<
 
+# .cu files
+%.cu_o: %.cu
+	$(NVCC) $(ALL_NVCCFLAGS) $(ALL_CPPFLAGS) -c -o $@ $<
+
+
+# Executables
+
+kinect: kinect.cpp kfusion.cu_o helpers.cu_o interface.o
+	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) $^ -o $@ $(ALL_LDFLAGS)
+
+test: test.cpp kfusion.cu_o helpers.cu_o
+	$(CXX) $(ALL_CPPFLAGS) $(ALL_CXXFLAGS) $^ -o $@ $(ALL_LDFLAGS)
+
+
+# Cleanup
+.PHONY: clean
 clean:
-	rm -rf *.o test kinect
+	rm -f *.cu_o *.o test kinect

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,14 @@ CC = nvcc
 CPPFLAGS=-I../include -I../include/libfreenect -I/usr/loca/cuda/include -I/opt/local/include -DLIBFREENECT_INTERFACE
 CXXFLAGS=-g -m64 -O3 -use_fast_math
 ## -ptx -src-in-ptx
-LDFLAGS=-g -m64 -L../lib -lfreenect -Xlinker -framework,OpenGL,-framework,GLUT
+LDFLAGS=-g -m64 -L../lib -lfreenect -Xlinker
+
+OS := $(shell uname)
+ifeq ($(OS),Darwin)
+LDFLAGS+=-framework,OpenGL,-framework,GLUT
+else
+LDFLAGS+=-lGL -lglut
+endif
 
 %.o: %.cu
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $^

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ test: kfusion.o helpers.o test.o
 kinect: kfusion.o helpers.o kinect.o interface.o
 
 clean:
-	rm *.o test kinect
+	rm -rf *.o test kinect

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ KFusion is mainly written in CUDA with some interface code to display graphics o
 Requirements
 ------------
 
+You need a depth camera: Either a Microsoft Kinect or any camera supported
+by OpenNI 2 (such as the Asus Xtion Pro Live).
+
 KFusion depends on the following libraries:
 
 * http://www.edwardrosten.com/cvd/toon.html
@@ -25,9 +28,10 @@ On Windows use the MS Kinect SDK:
 
 * http://www.microsoft.com/en-us/kinectforwindows/develop/overview.aspx
 
-while on other platforms use libfreenect:
+while on other platforms use either:
 
-* http://openkinect.org/
+* libfreenect: http://openkinect.org or
+* OpenNI: https://github.com/OpenNI/OpenNI2
 
 and of course the CUDA 5 SDK by NVidia
 

--- a/interface.cpp
+++ b/interface.cpp
@@ -325,4 +325,292 @@ int GetKinectFrame(){
     return depth_index;
 }
 
+// This implementation uses the OpenNI2 and pthreads for threading
+#elif defined(OPENNI2_INTERFACE)
+
+#include <OpenNI.h>
+#include <pthread.h>
+#include <iostream>
+#include <stdexcept>
+
+using namespace std;
+using namespace openni;
+
+Device device;
+VideoStream depth_stream;
+VideoStream color_stream;
+bool gotDepth = false; // set to true as soon as the first depth frame is received
+int depth_index = 0; // for flipping between the depth double buffers
+
+pthread_t openni_thread; // thread for the readFrame() loop
+volatile bool die = false; // tells the readFrame() loop to stop
+
+// We use OpenNI frame allocators to let it write new images directly
+// into our buffers (one for RGB and a double-buffer for depth) so that
+// we don't have to memcpy each frame.
+
+class KFusionDepthFrameAllocator : public VideoStream::FrameAllocator
+{
+private:
+    uint16_t * depth_buffers_[2];
+public:
+    KFusionDepthFrameAllocator(uint16_t * depth_buffers[2])
+    {
+        depth_buffers_[0] = depth_buffers[0];
+        depth_buffers_[1] = depth_buffers[1];
+    }
+    void *allocateFrameBuffer(int size)
+    {
+        if (size != 640*480*2) {
+            cout << "KFusionDepthFrameAllocator size request of " << size << " (should be " << 640*480*2 << ")" << endl;
+            throw runtime_error("KFusionDepthFrameAllocator got bad size request, currently only supports 640*480*2");
+        }
+        return depth_buffers_[depth_index];
+    }
+
+    // We have static buffers, nothing to do.
+    void freeFrameBuffer(void *data) {}
+};
+
+class KFusionColorFrameAllocator : public VideoStream::FrameAllocator
+{
+private:
+    unsigned char * rgb_buffer_;
+public:
+    KFusionColorFrameAllocator(unsigned char * rgb_buffer)
+    {
+        rgb_buffer_ = rgb_buffer;
+    }
+    void *allocateFrameBuffer(int size)
+    {
+        if (size != 640*480*3) {
+            cout << "KFusionColorFrameAllocator size request of " << size << " (should be " << 640*480*3 << ")" << endl;
+            throw runtime_error("KFusionColorFrameAllocator got bad size request, currently only supports 640*480*3");
+        }
+        return rgb_buffer_;
+    }
+
+    // We have static buffers, nothing to do.
+    void freeFrameBuffer(void *data) {}
+};
+
+// This thread continuously reads depth and RGB images from the camera
+// using the blocking readFrame().
+// We could have used OpenNI::waitForAnyStream() as an alternative,
+// but there is no direct benefit of it.
+void *openni_threadfunc(void *arg)
+{
+    while(!die){
+        Status status = STATUS_OK;
+
+        // Our FrameAllocators make sure the data lands in our buffers;
+        // that's why we never have to use the VideoFrameRefs.
+
+        // Next depth frame
+        VideoFrameRef depthFrame;
+        status = depth_stream.readFrame(&depthFrame);
+        if (status != STATUS_OK) {
+            printf("OpenNI: readFrame failed:\n%s\n", OpenNI::getExtendedError());
+            break;
+        } else {
+            depth_index = (depth_index+1) % 2; // Flip double buffers
+            gotDepth = true;
+        }
+
+        // Next RGB frame
+        VideoFrameRef colorFrame;
+        status = color_stream.readFrame(&colorFrame);
+        if (status != STATUS_OK) {
+            printf("OpenNI: readFrame failed:\n%s\n", OpenNI::getExtendedError());
+            break;
+        }
+    }
+    depth_stream.destroy();
+    color_stream.destroy();
+    device.close();
+    OpenNI::shutdown();
+    return NULL;
+}
+
+int InitKinect( uint16_t * depth_buffer[2], unsigned char * rgb_buffer )
+{
+    // The allocators must survive this initialization function.
+    KFusionDepthFrameAllocator *depthAlloc = new KFusionDepthFrameAllocator(depth_buffer);
+    KFusionColorFrameAllocator *colorAlloc = new KFusionColorFrameAllocator(rgb_buffer);
+
+    Status status = STATUS_OK;
+
+    // Initialize OpenNI
+    status = OpenNI::initialize();
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Initialize failed:\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Check if a camera is connected
+    Array<openni::DeviceInfo> deviceList;
+    OpenNI::enumerateDevices(&deviceList);
+    int nr_devices = deviceList.getSize();
+
+    if(nr_devices < 1) {
+        cout << "OpenNI: No devices found" << endl;
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Open device
+    status = device.open(ANY_DEVICE);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not open device:\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Create depth stream
+    if (device.getSensorInfo(SENSOR_DEPTH) != NULL) {
+        status = depth_stream.create(device, SENSOR_DEPTH);
+        if (status != STATUS_OK) {
+            printf("OpenNI: Could not create depth stream\n%s\n", OpenNI::getExtendedError());
+            OpenNI::shutdown();
+            return 1;
+        }
+    }
+
+    // Create color stream
+    if (device.getSensorInfo(SENSOR_COLOR) != NULL) {
+        status = color_stream.create(device, SENSOR_COLOR);
+        if (status != STATUS_OK) {
+            printf("OpenNI: Could not create color stream\n%s\n", OpenNI::getExtendedError());
+            OpenNI::shutdown();
+            return 1;
+        }
+    }
+
+    // Choose what depth format we want from the camera
+    VideoMode depth_mode;
+    depth_mode.setPixelFormat(PIXEL_FORMAT_DEPTH_1_MM);
+    depth_mode.setResolution(640, 480);
+    depth_mode.setFps(30);
+    status = depth_stream.setVideoMode(depth_mode);
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not set depth video mode:\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Choose what color format we want from the camera
+    VideoMode color_mode;
+    color_mode.setPixelFormat(PIXEL_FORMAT_RGB888);
+    color_mode.setResolution(640, 480);
+    color_mode.setFps(30);
+    status = color_stream.setVideoMode(color_mode);
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not set color video mode:\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Enable registration mode
+    status = device.setImageRegistrationMode(IMAGE_REGISTRATION_DEPTH_TO_COLOR);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not enable registration mode:\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Enable color-to-depth synchronization
+    status = device.setDepthColorSyncEnabled(true);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not enable color sync:\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Disable depth mirroring (we want to see the perspective of the camera)
+    status = depth_stream.setMirroringEnabled(false);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could enable mirroring on depth stream\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Disable color mirroring (we want to see the perspective of the camera)
+    status = color_stream.setMirroringEnabled(false);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could enable mirroring on color stream\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Use allocator to have OpenNI write directly into our depth buffers
+    status = depth_stream.setFrameBuffersAllocator(depthAlloc);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not set depth frame buffer allocator\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Use allocator to have OpenNI write directly into our color buffer
+    status = color_stream.setFrameBuffersAllocator(colorAlloc);
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not set color frame buffer allocator\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Start depth
+    status = depth_stream.start();
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not start the depth stream\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Start color
+    status = color_stream.start();
+
+    if (status != STATUS_OK) {
+        printf("OpenNI: Could not start the color stream\n%s\n", OpenNI::getExtendedError());
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    // Start spawn thread running openni_threadfunc to poll for new frames
+    int res = pthread_create(&openni_thread, NULL, openni_threadfunc, NULL);
+    if(res) {
+        cout << "error starting kinect thread " << res << endl;
+        OpenNI::shutdown();
+        return 1;
+    }
+
+    return 0;
+}
+
+void CloseKinect() {
+    die = true;
+    pthread_join(openni_thread, NULL);
+}
+
+bool KinectFrameAvailable() {
+    bool result = gotDepth;
+    gotDepth = false;
+    return result;
+}
+
+int GetKinectFrame() {
+    return depth_index;
+}
+
+#else
+#error "No camera driver interface specified!"
 #endif

--- a/interface.cpp
+++ b/interface.cpp
@@ -276,8 +276,10 @@ int InitKinect( uint16_t * depth_buffer[2], unsigned char * rgb_buffer ){
     freenect_select_subdevices(f_ctx, (freenect_device_flags)(FREENECT_DEVICE_MOTOR | FREENECT_DEVICE_CAMERA));
 
     int nr_devices = freenect_num_devices (f_ctx);
-    if (nr_devices < 1)
+    if (nr_devices < 1){
+        cout << "libfreenect: No devices found" << endl;
         return 1;
+    }
 
     if (freenect_open_device(f_ctx, &f_dev, 0) < 0) {
         cout << "libfreenect: Could not open device" << endl;

--- a/kinect.cpp
+++ b/kinect.cpp
@@ -267,6 +267,9 @@ int main(int argc, char ** argv) {
         return 1;
     }
 
+    cout << "Using depthImage size: " << depthImage[0].size.x*depthImage[0].size.y * sizeof(uint16_t) << " bytes " << endl;
+    cout << "Using rgbImage size: " << rgbImage.size.x*rgbImage.size.y * sizeof(uchar3) << " bytes " << endl;
+
     memset(depthImage[0].data(), 0, depthImage[0].size.x*depthImage[0].size.y * sizeof(uint16_t));
     memset(depthImage[1].data(), 0, depthImage[1].size.x*depthImage[1].size.y * sizeof(uint16_t));
     memset(rgbImage.data(), 0, rgbImage.size.x*rgbImage.size.y * sizeof(uchar3));

--- a/kinect.cpp
+++ b/kinect.cpp
@@ -26,6 +26,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "interface.h"
 #include "perfstats.h"
 
+#include <cstring>
 #include <iostream>
 #include <sstream>
 #include <iomanip>

--- a/kinect.cpp
+++ b/kinect.cpp
@@ -198,9 +198,24 @@ void exitFunc(void){
 }
 
 int main(int argc, char ** argv) {
-    const float size = (argc > 1) ? atof(argv[1]) : 2.f;
+    const float default_size = 2.f;
 
     KFusionConfig config;
+
+    // Search for --help argument
+    for (int i = 0; i < argc; ++i) {
+        if (string(argv[i]) == "--help") {
+            cout << "Usage: kinect [size] [dist_threshold] [normal_threshold]" << endl;
+            cout << endl;
+            cout << "Defaults:" << endl;
+            cout << "  size: " << default_size << endl;
+            cout << "  dist_threshold: " << config.dist_threshold << endl;
+            cout << "  normal_threshold: " << config.normal_threshold << endl;
+            return 0;
+        }
+    }
+
+    const float size = (argc > 1) ? atof(argv[1]) : default_size;
 
     // it is enough now to set the volume resolution once.
     // everything else is derived from that.

--- a/kinect.cpp
+++ b/kinect.cpp
@@ -107,17 +107,17 @@ void display(void){
 
     glClear(GL_COLOR_BUFFER_BIT);
     glRasterPos2i(0, 0);
-    glDrawPixels(lightScene);
+    glDrawPixels(lightScene); // left top
     glRasterPos2i(0, 240);
     glPixelZoom(0.5, -0.5);
-    glDrawPixels(rgbImage);
+    glDrawPixels(rgbImage); // left bottom
     glPixelZoom(1,-1);
     glRasterPos2i(320,0);
-    glDrawPixels(lightModel);
+    glDrawPixels(lightModel); // middle top
     glRasterPos2i(320,240);
-    glDrawPixels(trackModel);
+    glDrawPixels(trackModel); // middle bottom
     glRasterPos2i(640, 0);
-    glDrawPixels(texModel);
+    glDrawPixels(texModel); // right
     const double endProcessing = Stats.sample("draw");
 
     Stats.sample("total", endProcessing - startFrame, PerfStats::TIME);


### PR DESCRIPTION
I added OpenNI 2 support, which allows using KFusion with the Asus Xtion and other Primesense devices.

I also included a few other fixes and changed the Makefile so that the C++ compiler, include paths etc. can be set from outside the Makefile and don't need to be hardcoded.

My OpenNI error handling is rigorous but verbose. Tell me if you would prefer a macro instead to make calls+checks one-liners.
